### PR TITLE
ClientSideFilter does not correctly handle Unicode characters

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -245,7 +245,7 @@
        @return {RegExp} A RegExp object to match against model #fields.
      */
     makeRegExp: function (query) {
-	  return new RegExp(query.trim().split(/\s\w*/).join("|"), "i");
+	  return new RegExp(query.trim().split(/\s/).join("|"), "i");
     },
 
     /**


### PR DESCRIPTION
Hi, I made a new regular expression, and now it works with unicode. I tested it at the local machine and everything worked fine.
Search example:
1) Search "first example", regexp: "/first|example/i"
1) Search "первый пример", regexp: "/первый|пример/i"
