### PR TITLE
Reset Collection when the Search Input is Empty

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -423,13 +423,19 @@
        query answer.
     */
     search: function () {
+      var col = this.collection;
+      if (_.isEmpty(this.searchBox().val())) {
+    	  col.reset(this.shadowCollection.toArray(), {reindex: false});
+    	  return;
+      }
+    	
       var searchResults = this.index.search(this.searchBox().val());
       var models = [];
       for (var i = 0; i < searchResults.length; i++) {
         var result = searchResults[i];
         models.push(this.shadowCollection.get(result.ref));
       }
-      var col = this.collection;
+      
       if (col.pageableCollection) col.pageableCollection.getFirstPage({silent: true});
       col.reset(models, {reindex: false});
     }


### PR DESCRIPTION
When the User clears the Search Box it is expected that all previous entires are shown.

As of now the user gets an empty list.
