### PR TITLE
Typo fix for the ClientSideFilter documentation string

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -196,8 +196,8 @@
     fields: null,
 
     /**
-       @property [wait=149] The time in milliseconds to wait since for since the
-       last change to the search box's value before searching. This value can be
+       @property [wait=149] The time in milliseconds to wait since the last
+       change to the search box's value before searching. This value can be
        adjusted depending on how often the search box is used and how large the
        search index is.
     */


### PR DESCRIPTION
Just found this small typo while reading the source code to backgrid-filter.js.  Hope it's not a bother.
