### PR TITLE
Adds the baseParams option (see issue #33)

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -129,15 +129,17 @@
       Returns the data object
      */
     parseQueryParams: function () {
-      var data = {};
+      var data;
       var query = this.searchBox().val();
 
       if (this.baseParams) {
-        data = this.baseParams;
+        data = _.clone(this.baseParams);
 
-        if (query && this.baseParams[this.name]) {
-          query = this.mergeQueryString(this.baseParams[this.name], query);
+        if (query && data[this.name]) {
+          query = this.mergeQueryString(data[this.name], query);
         }
+      } else {
+        data = {};
       }
 
       if (query) data[this.name] = query;

--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -61,6 +61,11 @@
     placeholder: null,
 
     /**
+      @property {string} [baseParams] Parameters to be added on every request
+    */
+    baseParams: null,
+
+    /**
        @param {Object} options
        @param {Backbone.Collection} options.collection
        @param {string} [options.name]
@@ -72,6 +77,7 @@
       this.name = options.name || this.name;
       this.placeholder = options.placeholder || this.placeholder;
       this.template = options.template || this.template;
+      this.baseParams = options.baseParams || this.baseParams;
 
       // Persist the query on pagination
       var collection = this.collection, self = this;
@@ -110,6 +116,36 @@
     },
 
     /**
+      Merges the baseParams query with the query string from the search box
+
+      Returns the new query string.
+     */
+    mergeQueryString: function (baseQueryString, queryString) {
+      var queryArray = _.uniq((baseQueryString + ' ' + queryString).match(/\S+/g));
+      return queryArray.join(' ');
+    },
+
+    /**
+      Returns the data object
+     */
+    parseQueryParams: function () {
+      var data = {};
+      var query = this.searchBox().val();
+
+      if (this.baseParams) {
+        data = this.baseParams;
+
+        if (query && this.baseParams[this.name]) {
+          query = this.mergeQueryString(this.baseParams[this.name], query);
+        }
+      }
+
+      if (query) data[this.name] = query;
+
+      return data;
+    },
+
+    /**
        Upon search form submission, this event handler constructs a query
        parameter object and pass it to Collection#fetch for server-side
        filtering.
@@ -120,10 +156,7 @@
     search: function (e) {
       if (e) e.preventDefault();
 
-      var data = {};
-      var query = this.searchBox().val();
-      if (query) data[this.name] = query;
-
+      var data = this.parseQueryParams();
       var collection = this.collection;
 
       // go back to the first page on search
@@ -147,13 +180,19 @@
       this.showClearButtonMaybe();
 
       var collection = this.collection;
+      var args = {reset: true};
 
       // go back to the first page on clear
       if (Backbone.PageableCollection &&
           collection instanceof Backbone.PageableCollection) {
         collection.getFirstPage({reset: true, fetch: true});
       }
-      else collection.fetch({reset: true});
+      else {
+        if (this.baseParams) {
+          args.data = this.baseParams;
+          collection.fetch(args);
+        }
+      }
     },
 
     /**

--- a/test/filter.js
+++ b/test/filter.js
@@ -354,6 +354,10 @@ describe("A ServerSideFilter", function () {
     expect(data).toEqual({sticky: "arg val", q: "base query current"});
     expect(collection.length).toBe(1);
     expect(collection.at(0).toJSON()).toEqual({id: 1});
+
+    filter.searchBox().val("another query");
+    filter.$el.submit();
+    expect(data).toEqual({sticky: "arg val", q: "base query another"});
   });
 
   it("can clear the search box and refetch using the baseParams upon clicking the cross", function () {
@@ -373,6 +377,10 @@ describe("A ServerSideFilter", function () {
     filter.clearButton().click();
     expect(filter.searchBox().val()).toBe("");
     expect(filter.clearButton().css("display")).toBe("none");
+    expect(data).toEqual({sticky: "arg val", q: "base query"});
+
+    filter.searchBox().val("another query");
+    filter.clearButton().click();
     expect(data).toEqual({sticky: "arg val", q: "base query"});
   });
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -309,6 +309,72 @@ describe("A ServerSideFilter", function () {
     expect(filter.clearButton().css("display")).toBe("none");
   });
 
+  it("submits the baseParams when searching", function () {
+    var url, data;
+
+    $.ajax = function (settings) {
+      url = settings.url;
+      data = settings.data;
+      settings.success({id: 1});
+    };
+
+    var filter = new Backgrid.Extension.ServerSideFilter({
+      collection: collection,
+      baseParams: {sticky: "arg val"}
+    });
+
+    filter.render();
+    filter.searchBox();
+    filter.$el.submit();
+
+    expect(url).toBe("http://www.example.com");
+    expect(data).toEqual({sticky: "arg val"});
+    expect(collection.length).toBe(1);
+    expect(collection.at(0).toJSON()).toEqual({id: 1});
+  });
+
+  it("merges the existing query with the baseParams query", function () {
+    var url, data;
+
+    $.ajax = function (settings) {
+      url = settings.url;
+      data = settings.data;
+      settings.success({id: 1});
+    };
+
+    var filter = new Backgrid.Extension.ServerSideFilter({
+      collection: collection
+      , baseParams: {sticky: "arg val", q: "base query "}
+    });
+
+    filter.render();
+    filter.searchBox().val("current    query");
+    filter.$el.submit();
+    expect(url).toBe("http://www.example.com");
+    expect(data).toEqual({sticky: "arg val", q: "base query current"});
+    expect(collection.length).toBe(1);
+    expect(collection.at(0).toJSON()).toEqual({id: 1});
+  });
+
+  it("can clear the search box and refetch using the baseParams upon clicking the cross", function () {
+    var data;
+
+    $.ajax = function (settings) {
+      data = settings.data;
+    };
+
+    var filter = new Backgrid.Extension.ServerSideFilter({
+      collection: collection
+      , baseParams: {sticky: "arg val", q: "base query"}
+    });
+
+    filter.render();
+    filter.searchBox().val("query");
+    filter.clearButton().click();
+    expect(filter.searchBox().val()).toBe("");
+    expect(filter.clearButton().css("display")).toBe("none");
+    expect(data).toEqual({sticky: "arg val", q: "base query"});
+  });
 });
 
 describe("A ClientSideFilter", function () {


### PR DESCRIPTION
When baseParams are set, they will be sent, along with all other query params, on every request.