### PR TITLE
Add AMD support

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -9,7 +9,7 @@
 
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(["underscore", "backbone", "backgrid", "lunr"], factory);
+    define(["underscore", "backbone", "backgrid"], factory);
   } else if (typeof exports == "object") {
     // CommonJS
     (function () {


### PR DESCRIPTION
Adds AMD support. I should note that the extension still extends Backgrid via namespacing, it does not export/return anything. It also makes lunr a hard dependency for AMD users.
