### PR TITLE
Remove the default clear button on WebKit browsers

### DIFF
--- a/backgrid-filter.css
+++ b/backgrid-filter.css
@@ -179,6 +179,14 @@
 }
 
 /*
+ * Remove the default clear button on WebKit browsers
+ */
+
+.backgrid-filter input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+/*
  * Remove inner padding and border in Firefox 4+.
  */
 


### PR DESCRIPTION
Without this fix, the default clear button was shown in Google Chrome 36.0.1985.143 on Mac OS X 10.9.4:

![Screenshot](http://i.imgur.com/ONZjeQ5.png)
