### PR TITLE
Use query() for the queryParams in constructor

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -88,7 +88,7 @@
           collection instanceof Backbone.PageableCollection &&
           collection.mode == "server") {
         collection.queryParams[this.name] = function () {
-          return self.searchBox().val() || null;
+          return self.query() || null;
         };
       }
     },


### PR DESCRIPTION
Use query() for the queryParams instead of searchBox().val(). This makes it easier to extend/override behaviour.
Thanks!