### PR TITLE
Fixed typo in lunr.js bower package name.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "backbone": "~1.2.3",
     "backgrid": "~0.3.7",
-    "lunr": "^0.7.0",
+    "lunr.js": "^0.7.0",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
@wyuenho thank you for putting together this package.  I'm running into bower install errors because of a typo in lunr--should be `lunr.js` instead of `lunr`.