### PR TITLE
requrie('luna') instead of 'luna.js'.

### DIFF
--- a/backgrid-filter.js
+++ b/backgrid-filter.js
@@ -27,7 +27,7 @@
     define(function (require, exports, module) {
       var lunr;
       try {
-        lunr = require("lunr.js")
+        lunr = require("lunr")
       } catch (e) {}
 
       return factory(require("underscore"),


### PR DESCRIPTION
Using '.js' will force ajax call for luna.js and will not use preconfiguration luna module